### PR TITLE
feat(seo): add sitemap, robots.txt, and JSON-LD structured data

### DIFF
--- a/.claude/rules/overview.md
+++ b/.claude/rules/overview.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Beautiful Mapbox GL components, made simple. A collection of free and open-source map components built with React, TypeScript, Tailwind CSS, and Mapbox GL JS. Perfect companion for shadcn/ui.
+Composable map components for React. A collection of open-source animated map components built with React, TypeScript, and Tailwind CSS. Compatible with Mapbox GL JS and MapLibre GL. Perfect companion for shadcn/ui.
 
 ## Tech Stack
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: issue
+description: Read a GitHub issue, summarize it, and create a branch for it
+allowed-tools: Bash(gh *), Bash(git *)
+---
+
+# Issue Skill
+
+Read a GitHub issue by number or URL, summarize it, then create a working branch.
+
+## Repository
+
+`alamenai/terrae` — https://github.com/alamenai/terrae/issues
+
+## Arguments
+
+The user provides either:
+
+- An issue number (e.g., `42`)
+- A GitHub issue URL (e.g., `https://github.com/alamenai/terrae/issues/42`)
+
+If a URL is provided, extract the issue number from it.
+
+## Instructions
+
+1. **Fetch the Issue**
+   - Run `gh issue view <number> --repo alamenai/terrae` to read the issue
+   - If the issue doesn't exist, tell the user and stop
+
+2. **Summarize the Issue**
+   - Display the issue title and number
+   - Summarize the description in 2-3 bullet points
+   - List any labels
+   - Note if there are linked PRs or assignees
+
+3. **Determine Branch Name**
+   - Infer the type from labels or content:
+     - `bug` label or bug description → `fix/`
+     - `enhancement` or `feature` label → `feat/`
+     - `documentation` label → `docs/`
+     - Otherwise → `feat/`
+   - Build the branch name: `type/issue-number-short-description`
+   - Keep the description part short (2-4 words, kebab-case)
+   - Examples:
+     - `feat/42-add-heatmap-component`
+     - `fix/17-marker-memory-leak`
+     - `docs/8-update-installation-guide`
+
+4. **Create the Branch**
+   - Make sure we're on `main` and up to date: `git checkout main && git pull`
+   - Create and switch to the new branch: `git checkout -b <branch-name>`
+   - Confirm the branch was created
+
+5. **Report**
+   - Show the branch name
+   - Remind the user what the issue is about so they can start working

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pr
+description: Commit, push, and open a pull request on GitHub
+allowed-tools: Bash(git *), Bash(gh *)
+---
+
+# Pull Request Skill
+
+Commit changes, push the branch, and open a pull request on GitHub.
+
+## Instructions
+
+1. **Check Current State**
+   - Run `git status` to see changed files
+   - Run `git diff --staged` and `git diff` to see all changes
+   - Run `git log --oneline -5` to see recent commits
+
+2. **Stage and Commit**
+   - Stage specific files by name (avoid `git add -A` or `git add .`)
+   - Never stage sensitive files (.env, credentials, etc.)
+   - Follow conventional commit format: `type(scope): description`
+   - Keep commit messages concise (under 72 characters)
+
+3. **Create or Use Branch**
+   - If on `main`, create a new branch: `git checkout -b <branch-name>`
+   - Branch name format: `type/short-description` (e.g., `feat/code-comparison`, `fix/marker-cleanup`)
+   - If already on a feature branch, use it
+
+4. **Push to Remote**
+   - Push with upstream tracking: `git push -u origin <branch-name>`
+
+5. **Assign Labels**
+   Add `--label` flags to `gh pr create` based on the PR type and scope.
+
+   **Type labels** — pick based on the commit type:
+   | Commit type | Label |
+   |-------------|-------|
+   | `fix` | `bug` |
+   | `feat` | `enhancement` |
+   | `docs` | `documentation` |
+   | `test` | (no type label) |
+   | `refactor` | (no type label) |
+   | `chore` | (no type label) |
+
+   **Component labels** — if the scope matches a component label in the repo, add it:
+   | Scope | Label |
+   |-------|-------|
+   | `compass` | `Compass` |
+   | `interaction` | `Interaction` |
+
+   Run `gh label list` to check available labels if unsure. Multiple labels can be combined:
+
+   ```bash
+   gh pr create --label "bug" --label "Compass" ...
+   ```
+
+6. **Open Pull Request**
+   - Use `gh pr create` to open the PR
+   - Write a clear title (under 70 characters)
+   - Write a description that follows the structure below based on PR type
+   - Start with a **Type** checklist — check the one that applies:
+
+   ```bash
+   gh pr create --title "type(scope): description" --label "label" --body "$(cat <<'EOF'
+   ## Type
+
+   - [ ] Feature
+   - [ ] Bug fix
+   - [ ] Refactor
+   - [ ] Test
+   - [ ] Docs
+   - [ ] Chore
+
+   ## Summary
+   - bullet points describing what changed and why
+
+   ## Bug Details (only for bug fixes)
+   **What was the bug?**
+   Describe the incorrect behavior.
+
+   **Why did it happen?**
+   Explain the root cause.
+
+   **How was it fixed?**
+   Describe the solution.
+
+   ## Test Coverage
+   If tests were added or updated, link to the file on the branch (permalink):
+   - [`src/registry/map/__tests__/component.test.tsx`](https://github.com/alamenai/terrae/blob/<branch-name>/src/registry/map/__tests__/component.test.tsx)
+   EOF
+   )"
+   ```
+
+7. **Verify and Report**
+   - Show the PR URL to the user
+   - Run `git status` to confirm clean state
+
+## Important Rules
+
+- Do NOT push to `main` directly — always use a feature branch
+- Do NOT force push unless explicitly requested
+- Ask user before proceeding with each step

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ const siteDescription =
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: "terrae - Beautiful maps made simple",
+    default: "terrae - Composable map components for React",
     template: "%s - terrae",
   },
   description: siteDescription,
@@ -62,20 +62,20 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: siteUrl,
     siteName: siteName,
-    title: "terrae - Beautiful maps made simple",
+    title: "terrae - Composable map components for React",
     description: siteDescription,
     images: [
       {
         url: "/banner.png",
         width: 1200,
         height: 630,
-        alt: "terrae - Beautiful maps, made simple",
+        alt: "terrae - Composable map components for React",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "terrae - Beautiful maps made simple",
+    title: "terrae - Composable map components for React",
     description: siteDescription,
     creator: creator,
     images: ["/banner.png"],
@@ -95,6 +95,30 @@ const RootLayout = ({
     <html lang="en" className={`${geist.variable} ${geistMono.variable}`} suppressHydrationWarning>
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5, user-scalable=yes" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@graph": [
+                {
+                  "@type": "WebSite",
+                  name: siteName,
+                  url: siteUrl,
+                  description: siteDescription,
+                  publisher: { "@type": "Organization", name: siteName, url: siteUrl },
+                },
+                {
+                  "@type": "Organization",
+                  name: siteName,
+                  url: siteUrl,
+                  logo: `${siteUrl}/banner.png`,
+                  sameAs: ["https://github.com/alamenai/terrae"],
+                },
+              ],
+            }),
+          }}
+        />
       </head>
       <body className="font-sans antialiased">
         <ThemeProvider>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next"
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.terrae.dev"
+
+const robots = (): MetadataRoute.Robots => {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  }
+}
+
+export default robots

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,92 @@
+import type { MetadataRoute } from "next"
+import { getAllPosts } from "@/lib/content"
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://www.terrae.dev"
+
+const DOC_ROUTES = [
+  "",
+  "/installation",
+  "/comparison",
+  "/components",
+  "/hooks",
+  "/api-reference",
+  "/story",
+  "/changelog",
+  "/basic-map",
+  "/controls",
+  "/compass",
+  "/markers",
+  "/popups",
+  "/markers-animated",
+  "/animated-pulse",
+  "/footprint",
+  "/blur-area",
+  "/camera-follow",
+  "/compare",
+  "/grid",
+  "/heatmaps",
+  "/minimap",
+  "/radar",
+  "/sync",
+  "/targeting-reticle",
+  "/watermark",
+  "/arc-animated",
+  "/lines-animated",
+  "/lines-radial",
+  "/lines",
+  "/animated-circle",
+  "/animated-polygon",
+  "/choropleth",
+  "/circle",
+  "/circle-clusters",
+  "/polygon",
+  "/image",
+  "/music-disc",
+  "/raster-video",
+  "/cyclone",
+  "/explosion",
+  "/fire",
+  "/lightning",
+  "/meteor",
+  "/rain",
+  "/sandstorm",
+  "/snow",
+  "/steam",
+  "/tsunami",
+]
+
+const sitemap = (): MetadataRoute.Sitemap => {
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ]
+
+  const docPages: MetadataRoute.Sitemap = DOC_ROUTES.map((route) => {
+    return {
+      url: `${SITE_URL}/docs${route}`,
+      changeFrequency: "monthly" as const,
+      priority: route === "" ? 0.9 : 0.7,
+    }
+  })
+
+  const blogPosts: MetadataRoute.Sitemap = getAllPosts().map((post) => {
+    return {
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: new Date(post.date),
+      changeFrequency: "yearly" as const,
+      priority: 0.6,
+    }
+  })
+
+  return [...staticPages, ...docPages, ...blogPosts]
+}
+
+export default sitemap


### PR DESCRIPTION
## Summary
- Add dynamic `sitemap.xml` generation covering all 49 doc pages, blog posts, and static pages with prioritized entries
- Add `robots.txt` allowing all crawlers, disallowing `/api/`, and referencing the sitemap
- Add WebSite and Organization JSON-LD structured data schemas to the root layout for improved search engine rich results and sitelinks
- Update site tagline to "Composable map components for React"

## Test plan
- [x] `next build` passes with `/sitemap.xml` and `/robots.txt` in the output
- [ ] Verify `/sitemap.xml` renders correct XML in browser after deploy
- [ ] Verify `/robots.txt` renders correctly in browser after deploy
- [ ] Validate JSON-LD with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Submit sitemap in Google Search Console after deploy